### PR TITLE
chore: update CODEOWNERS for hyperledger-firefly org migration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# firefly-ui maintainers
-* @hyperledger/firefly-sdk-nodejs-maintainers
+* @hyperledger-firefly/firefly-sdk-nodejs-maintainers


### PR DESCRIPTION
Updates the CODEOWNERS file to reference the `hyperledger-firefly` GitHub organisation instead of `hyperledger` following repo migration.